### PR TITLE
terminate stack python example

### DIFF
--- a/source/includes/stack.md
+++ b/source/includes/stack.md
@@ -510,7 +510,7 @@ reuse_volumes | Wheather to reuse container volumes for this redeploy operation 
 import tutum
 
 stack = tutum.Stack.fetch("46aca402-2109-4a70-a378-760cfed43816")
-stack.terminate()
+stack.delete()
 ```
 
 ```go


### PR DESCRIPTION
The python example for stack terminating is wrong. There is no `terminate()` method in the code.
But there is `delete()`: https://github.com/tutumcloud/python-tutum/blob/staging/tutum/api/base.py#L195

So, this is either typo in the doc, or wrong method name in the code, because for tutum-go and tutum-cli is the method consistently named as "terminate".